### PR TITLE
Add elasticsearch search of items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,9 @@ gem "validate_url"
 # Manages object tagging
 gem "acts-as-taggable-on"
 
+# Elasticsearch clients
+gem "chewy"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,10 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chewy (7.2.7)
+      activesupport (>= 5.2)
+      elasticsearch (>= 7.12.0, < 7.14.0)
+      elasticsearch-dsl
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     dartsass-rails (0.4.1)
@@ -95,6 +99,15 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
+    elasticsearch (7.13.3)
+      elasticsearch-api (= 7.13.3)
+      elasticsearch-transport (= 7.13.3)
+    elasticsearch-api (7.13.3)
+      multi_json
+    elasticsearch-dsl (0.1.10)
+    elasticsearch-transport (7.13.3)
+      faraday (~> 1)
+      multi_json
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -103,6 +116,29 @@ GEM
       railties (>= 5.0.0)
     faker (3.1.0)
       i18n (>= 1.8.11, < 2)
+    faraday (1.10.3)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
     globalid (1.0.0)
       activesupport (>= 5.0)
     govspeak (7.0.2)
@@ -165,6 +201,8 @@ GEM
     mini_mime (1.1.2)
     minitest (5.17.0)
     msgpack (1.6.0)
+    multi_json (1.15.0)
+    multipart-post (2.3.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -274,6 +312,7 @@ GEM
     rubocop-rspec (2.15.0)
       rubocop (~> 1.33)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sanitize (6.0.0)
       crass (~> 1.0.2)
@@ -338,6 +377,7 @@ DEPENDENCIES
   awesome_nested_set
   bootsnap
   capybara
+  chewy
   dartsass-rails
   debug
   factory_bot_rails

--- a/README.md
+++ b/README.md
@@ -1,24 +1,42 @@
-# README
+Knowledge Hub
+===============
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+Elasticsearch
+-------------
 
-Things you may want to cover:
+Elasticsearch functionality is provided via the [chewy gem](https://github.com/toptal/chew).
 
-* Ruby version
+The easiest way to start up an Elasticsearch instance locally is via docker:
 
-* System dependencies
+```bash
+$ docker run --rm --name elasticsearch -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" elasticsearch:7.11.1
+```
 
-* Configuration
+### Import items into Elasticsearch
 
-* Database creation
+If Elasticsearch is running, when an item is created or update, a matching
+record in Elasticsearch will be create or update respectively.
 
-* Database initialization
+If items have been created without Elasticsearch present, they can be
+imported via:
 
-* How to run the test suite
+```ruby
+ItemsIndex.import
+```
 
-* Services (job queues, cache servers, search engines, etc.)
+There is also a Rake task that will do this:
 
-* Deployment instructions
+```bash
+rake elasticsearch:import
+```
 
-* ...
+A complimentary task will purge the database:
+
+```bash
+rake elasticsearch:purge
+```
+
+### Specs and Elasticsearch
+
+For the spec to pass, an instance of elasticsearch needs to be running on
+port 9200 (check config/chewy.yml for current setting)

--- a/app/chewy/items_index.rb
+++ b/app/chewy/items_index.rb
@@ -1,0 +1,6 @@
+class ItemsIndex < Chewy::Index
+  index_scope Item
+  field :name
+  field :description
+  field :tag_list
+end

--- a/app/chewy/items_search.rb
+++ b/app/chewy/items_search.rb
@@ -1,0 +1,25 @@
+class ItemsSearch
+  INDEX = ItemsIndex
+
+  def self.search(query)
+    new(query).search
+  end
+
+  attr_reader :query
+
+  def initialize(query)
+    @query = query
+  end
+
+  def search
+    if query.present?
+      INDEX.query(
+        query_string: {
+          fields: %i[name description tag_list],
+          query:,
+          default_operator: "and",
+        },
+      )
+    end
+  end
+end

--- a/app/controllers/item_searches_controller.rb
+++ b/app/controllers/item_searches_controller.rb
@@ -1,0 +1,5 @@
+class ItemSearchesController < ApplicationController
+  def index
+    @search = ItemsSearch.search(params[:query])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,8 @@
 module ApplicationHelper
   require "govspeak"
   def govspeak_to_html(govspeak)
+    return unless govspeak.present?
+
     doc = Govspeak::Document.new govspeak
     doc.to_html.html_safe
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,4 +10,6 @@ class Item < ApplicationRecord
 
   validates :name, :description, presence: true
   validates :source_url, url: true
+
+  update_index("items") { self }
 end

--- a/app/views/item_searches/index.html.erb
+++ b/app/views/item_searches/index.html.erb
@@ -1,0 +1,13 @@
+<h1>Item Search</h1>
+
+<% if @search&.documents.present?  %>
+  <ul>
+    <% @search.documents.each do |item| %>
+      <li class="item">
+        <%= link_to item.name, item %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>No results found</p>
+<% end %>

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -1,0 +1,4 @@
+<%= form_tag(item_searches_path, method: :get) do %>
+  <%= text_field_tag 'query', params[:query] %>
+  <%= submit_tag 'Submit' %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,12 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= image_tag('favicon.ico') %>" type="image/x-icon">
-    <link rel="mask-icon" href="<%= image_tag('govuk-mask-icon.svg') %>" color="#0b0c0c">
-    <link rel="apple-touch-icon" sizes="180x180" href="<%= image_tag('govuk-apple-touch-icon-180x180.png') %>">
-    <link rel="apple-touch-icon" sizes="167x167" href="<%= image_tag('govuk-apple-touch-icon-167x167.png') %>">
-    <link rel="apple-touch-icon" sizes="152x152" href="<%= image_tag('govuk-apple-touch-icon-152x152.png') %>">
-    <link rel="apple-touch-icon" href="<%= image_tag('govuk-apple-touch-icon.png') %>">
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_path('favicon.ico') %>" type="image/x-icon">
+    <link rel="mask-icon" href="<%= asset_path('govuk-mask-icon.svg') %>" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_path('govuk-apple-touch-icon-180x180.png') %>">
+    <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_path('govuk-apple-touch-icon-167x167.png') %>">
+    <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_path('govuk-apple-touch-icon-152x152.png') %>">
+    <link rel="apple-touch-icon" href="<%= asset_path('govuk-apple-touch-icon.png') %>">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -29,20 +29,21 @@
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-          <%= content_tag(:p, notice, class: 'notice', style: "color: green") if notice.present? %>
-          <%= content_tag(:p, alert, class: 'alert', style: "color: red") if alert.present? %>
-          <%= link_to 'Items:', items_path %>
-          <% Item.roots.each do |root_item| %>
-            <%= link_to root_item.name, root_item %>
-          <% end %>
-          <%= yield %>
+            <%= content_tag(:p, notice, class: 'notice', style: "color: green") if notice.present? %>
+            <%= content_tag(:p, alert, class: 'alert', style: "color: red") if alert.present? %>
+            <%= render "layouts/search" %>
+            <%= link_to 'Items:', items_path %>
+            <% Item.roots.each do |root_item| %>
+              <%= link_to root_item.name, root_item %>
+            <% end %>
+            <%= yield %>
+          </div>
         </div>
-      </div>
-    </main>
-  </div>
-  <%= render "layouts/footer" %>
-  <script>
-    window.GOVUKFrontend.initAll()
-  </script>
-</body>
+      </main>
+    </div>
+    <%= render "layouts/footer" %>
+    <script>
+      window.GOVUKFrontend.initAll()
+    </script>
+  </body>
 </html>

--- a/config/chewy.yml
+++ b/config/chewy.yml
@@ -1,0 +1,7 @@
+# config/chewy.yml
+# separate environment configs
+test:
+  host: 'localhost:9200'
+  prefix: 'test'
+development:
+  host: 'localhost:9200'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
   root "home#index"
 
   resources :items
+  resources :item_searches, only: [:index]
 end

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,0 +1,11 @@
+namespace :elasticsearch do
+  desc "Index items into elasticsearch via import"
+  task import: :environment do
+    ItemsIndex.import
+  end
+
+  desc "Purge items from elasticsearch"
+  task purge: :environment do
+    ItemsIndex.purge!
+  end
+end

--- a/spec/chewy/items_search_spec.rb
+++ b/spec/chewy/items_search_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ItemsSearch, elasticsearch: true do
+  describe ".search" do
+    let(:text) { Faker::Lorem.word }
+    let!(:item) { create :item, name: "Foo #{text} bar" }
+
+    it "returns the item if name matches" do
+      ItemsIndex.import
+      expect(described_class.search(text).documents).to include(item)
+    end
+  end
+end

--- a/spec/requests/item_searches_spec.rb
+++ b/spec/requests/item_searches_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "ItemSearches", type: :request, elasticsearch: true do
+  describe "GET /index" do
+    it "returns http success" do
+      get item_searches_path
+      expect(response).to have_http_status(:success)
+    end
+
+    it "states nothing found" do
+      get item_searches_path
+      expect(response.body).to include("No results found")
+    end
+
+    context "when passed a query" do
+      let(:text) { Faker::Lorem.word }
+      let!(:item) { create :item, name: "Foo #{text} bar" }
+
+      it "displays a link to the matching item" do
+        get item_searches_path, params: { query: text }
+        expect(response.body).to include(item_path(item))
+      end
+    end
+  end
+end

--- a/spec/support/chewy.rb
+++ b/spec/support/chewy.rb
@@ -1,0 +1,7 @@
+require "chewy/rspec"
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    Chewy.strategy(:bypass)
+  end
+end

--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -1,0 +1,6 @@
+RSpec.configure do |config|
+  # start an in-memory cluster for Elasticsearch as needed
+  config.before :all, elasticsearch: true do
+    ItemsIndex.purge!
+  end
+end


### PR DESCRIPTION
This change uses the [Chewy gem](https://github.com/toptal/chewy) to provide Elasticsearch functionality.

A search form has been added to the layout so that it appears at the top of all views.

Output from a search submission is displayed as a list of matching items.

<img width="593" alt="foo_search_result" src="https://user-images.githubusercontent.com/119297020/216590881-130b26b2-23f1-402c-9fd4-2e84bee24784.png">

Note the comments in the README regarding needing to have a local instance of elasticsearch running for tests to pass following this change.

Also a small tidy up of the application layout to fix a bug where the end of lines in the head, were displayed at the top of the page.