### PR TITLE
Add the ability to add comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,55 @@
+class CommentsController < ApplicationController
+  before_action :set_comment, only: %i[show edit update destroy]
+  before_action :set_item, only: %i[show edit update destroy create index new]
+
+  def index
+    @comments = Comment.all
+  end
+
+  def show; end
+
+  def new
+    @comment = @item.comments.new
+  end
+
+  def edit; end
+
+  def create
+    @comment = @item.comments.new(comment_params)
+
+    if @comment.save
+      redirect_to @item, notice: "Comment was successfully created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @comment.update(comment_params)
+      redirect_to @item, notice: "Comment was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @comment.destroy
+    redirect_to @item, notice: "Comment was successfully destroyed."
+  end
+
+private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_comment
+    @comment = Comment.find(params[:id])
+  end
+
+  def set_item
+    @item = Item.find(params[:item_id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def comment_params
+    params.require(:comment).permit(:body, :item_id)
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :item
+  validates :body, presence: true
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,6 +8,8 @@ class Item < ApplicationRecord
   acts_as_nested_set counter_cache: "children_count"
   acts_as_taggable_on :tags
 
+  has_many :comments
+
   validates :name, :description, presence: true
   validates :source_url, url: true
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,7 @@
+<% if comment.persisted? %>
+  <div>
+    <div>
+      <%= comment.body %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: [item, comment]) do |form| %>
+  <% if comment.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(comment.errors.count, "error") %> prohibited this comment from being saved:</h2>
+
+      <ul>
+        <% comment.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :body, style: "display: block" %>
+    <%= form.text_area :body %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Editing comment</h1>
+
+<%= render "form", comment: @comment, item: @item %>
+
+<br>
+
+<div>
+  <%= link_to "Show this comment", item_comment_path(@item, @comment) %> |
+  <%= link_to "Back to comments", item_comments_path %>
+</div>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,0 +1,12 @@
+<h1>Comments</h1>
+
+<div id="comments">
+  <% @comments.each do |comment| %>
+    <%= render comment %>
+    <p>
+      <%= link_to "Show this comment", [@item, comment] %>
+    </p>
+  <% end %>
+</div>
+
+<%= link_to "New comment", new_item_comment_path %>

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,0 +1,9 @@
+<h1>New comment</h1>
+
+<%= render "form", comment: @comment, item: @item %>
+
+<br>
+
+<div>
+  <%= link_to "Back to comments", item_comments_path %>
+</div>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -1,0 +1,8 @@
+<%= render @comment %>
+
+<div>
+  <%= link_to "Edit this comment", edit_item_comment_path(@comment) %> |
+  <%= link_to "Back to comments", item_comments_path %>
+
+  <%= button_to "Destroy this comment", item_comment_path(@comment), method: :delete %>
+</div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -40,3 +40,18 @@
 
   <%= button_to "Destroy this item", @item, method: :delete %>
 </div>
+
+<div>
+  <div>
+    <p>Comments</p>
+    <%= form_with(model: [@item, @item.comments.build]) do |f| %>
+      <div class="govuk-form-group">
+        <%= f.label :body, 'New comment' %>
+        <%= f.text_area :body %>
+      </div>
+      <%= f.submit 'Submit' %>
+    <% end %>
+  </div>
+</div>
+
+<%= render @item.comments %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,8 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "home#index"
-
-  resources :items
+  resources :items do
+    resources :comments
+  end
   resources :item_searches, only: [:index]
 end

--- a/db/migrate/20230201164833_create_comments.rb
+++ b/db/migrate/20230201164833_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.text :body
+      t.references :item
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_26_110857) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_01_164833) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "comments", force: :cascade do |t|
+    t.text "body"
+    t.bigint "item_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_comments_on_item_id"
+  end
 
   create_table "items", force: :cascade do |t|
     t.string "name"

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :comment do
+    body { Faker::Lorem.paragraph }
+    item
+  end
+end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe "/comments", type: :request do
+  let(:valid_attributes) do
+    attributes_for :comment
+  end
+
+  let(:invalid_attributes) do
+    {
+      body: "",
+    }
+  end
+
+  let(:item) { create :item }
+  let(:comment) { item.comments.create! valid_attributes }
+
+  describe "GET /index" do
+    it "renders a successful response" do
+      get item_comments_path(item_id: item)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /show" do
+    it "renders a successful response" do
+      get item_comment_path(item, comment)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /new" do
+    it "renders a successful response" do
+      get new_item_comment_path(item)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /edit" do
+    it "renders a successful response" do
+      get edit_item_comment_path(item, comment)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST /create" do
+    subject(:post_comment) do
+      post item_comments_path(item), params: { comment: params }
+    end
+    context "with valid parameters" do
+      let(:params) { valid_attributes }
+      it "creates a new Comment" do
+        expect {
+          post_comment
+        }.to change(Comment, :count).by(1)
+      end
+
+      it "redirects to the item the comment was created on" do
+        post_comment
+        expect(response).to redirect_to(item_url(Item.last))
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:params) { invalid_attributes }
+      it "does not create a new Comment" do
+        expect {
+          post_comment
+        }.to change(Comment, :count).by(0)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        post_comment
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    context "with valid parameters" do
+      let(:new_attributes) do
+        attributes_for :comment
+      end
+
+      it "updates the requested comment" do
+        patch item_comment_path(item, comment), params: { comment: new_attributes }
+        comment.reload
+        expect(comment.body).to eq(new_attributes[:body])
+      end
+
+      it "redirects to the item associated with the requested comment" do
+        patch item_comment_path(item, comment), params: { comment: new_attributes }
+        comment.reload
+        expect(response).to redirect_to(item_url(item))
+      end
+    end
+
+    context "with invalid parameters" do
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        patch item_comment_path(item, comment), params: { comment: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "DELETE /destroy" do
+    it "destroys the requested comment" do
+      item
+      comment
+      expect {
+        delete item_comment_path(item, comment)
+      }.to change(Comment, :count).by(-1)
+    end
+
+    it "redirects to the item" do
+      delete item_comment_path(item, comment)
+      expect(response).to redirect_to(item_path(item))
+    end
+  end
+end


### PR DESCRIPTION
Some of the views and the functionality in the comments controller isn't currently used but might be in the future so I've left it in, for example the ability to edit and delete comments.

The comments are nested inside Item objects, and redirects in the controller go back to the Item the comment belongs to.