### PR TITLE
Add x86_64-linux platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.14.0-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.0-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
@@ -378,6 +380,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   acts-as-taggable-on


### PR DESCRIPTION
I'm adding this because when trying to deploy the app on heroku I'm getting the following error:

``Your bundle only supports platforms ["arm64-darwin-21"] but your local platform is x86_64-linux. Add the current platform to the lockfile with `bundle lock --add-platform x86_64-linux` and try again.``