### PR TITLE
Add github action

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -1,0 +1,80 @@
+# This workflow will install a prebuilt Ruby version, install dependencies, and
+# run tests and linters.
+name: "Ruby on Rails CI"
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Configure Elasticsearch
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Runs Elasticsearch
+        uses: elastic/elastic-github-actions/elasticsearch@master
+        with:
+          stack-version: 7.6.0
+
+      # Cofigure JavaScript environment
+      - name: Set Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
+      - name: Run install
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: install # will run `yarn install` command
+
+      # Configure Ruby and Rails environment
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4 # v1.127.0
+        with:
+          bundler-cache: true
+
+      # Add or replace database setup steps here
+      - name: Set up database schema
+        run: bin/rails db:schema:load
+
+      - name: Build assets
+        run: bundle exec rails dartsass:build
+
+      # Add or replace test runners here
+      - name: Run tests
+        run: bin/rake
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4 # v1.127.0
+        with:
+          bundler-cache: true
+      # Add or replace any other lints here
+      - name: Lint Ruby files
+        run: bin/lint

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,4 +13,17 @@ module ApplicationHelper
   def item_path(item)
     location_item_path(item.location, item)
   end
+
+  # This is a horrible hack, but I've been unable to find a better solution.
+  # If tmp/cache is empty when an asset path is first called an error occurs:
+  #  ` LoadError: cannot load such file -- sassc`
+  # sassc is not present in this app, so it looks like a relic of older Rails systems.
+  # The code below catches that error and then waits for the tmp/cache to build.
+  # The first call to render the page generates the tmp/cache build even if it errors.
+  def catch_load_error
+    yield
+  rescue LoadError
+    sleep 0.1
+    retry
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,18 +6,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_path('favicon.ico') %>" type="image/x-icon">
-    <link rel="mask-icon" href="<%= asset_path('govuk-mask-icon.svg') %>" color="#0b0c0c">
-    <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_path('govuk-apple-touch-icon-180x180.png') %>">
-    <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_path('govuk-apple-touch-icon-167x167.png') %>">
-    <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_path('govuk-apple-touch-icon-152x152.png') %>">
-    <link rel="apple-touch-icon" href="<%= asset_path('govuk-apple-touch-icon.png') %>">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag "application" %>
+    <%= catch_load_error do %>
+      <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_path('favicon.ico') %>" type="image/x-icon">
+      <link rel="mask-icon" href="<%= asset_path('govuk-mask-icon.svg') %>" color="#0b0c0c">
+      <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_path('govuk-apple-touch-icon-180x180.png') %>">
+      <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_path('govuk-apple-touch-icon-167x167.png') %>">
+      <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_path('govuk-apple-touch-icon-152x152.png') %>">
+      <link rel="apple-touch-icon" href="<%= asset_path('govuk-apple-touch-icon.png') %>">
 
-    <%= javascript_include_tag "application" %>
+      <%= csrf_meta_tags %>
+      <%= csp_meta_tag %>
+
+      <%= stylesheet_link_tag "application" %>
+      <%= javascript_include_tag "application" %>
+    <% end %>
   </head>
 
   <body class="govuk-template__body">

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+bundle exec rubocop

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "/items", type: :request do
 
       it "associates the tags with the item" do
         patch location_item_path(location, item), params: { item: attributes }
-        expect(item.reload.tag_list).to eq(tags)
+        expect(item.reload.tag_list).to match_array(tags)
       end
     end
   end


### PR DESCRIPTION
The git hub action is a modification of the **Ruby on Rails** configuration [provided by github via the Actions tab](https://github.com/co-cddo/knowledge-hub/actions/newhttps://github.com/co-cddo/knowledge-hub/actions/new).

The main modification from the default were:

- add elasticsearch instance
- ensure JavaScript environment configured
- load CSS via Dart CSS
- add lint bin file with rubocop command

In addition a [bug fix](https://github.com/rails/dartsass-rails/issues/37) was added as on first build the tmp/caches isn't built and this causes an error:
```
LoadError:
       cannot load such file -- sassc
```
I also fixed an occasional error where the tags ordering may not be consistent.