### PR TITLE
Exclude unwanted content from search

### DIFF
--- a/app/services/html_scraper.rb
+++ b/app/services/html_scraper.rb
@@ -7,6 +7,8 @@ class HtmlScraper
 
   attr_reader :url
 
+  TAGS_TO_EXCLUDE = %w[style script].freeze
+
   def initialize(url)
     @url = url
   end
@@ -18,7 +20,11 @@ class HtmlScraper
 private
 
   def document
-    Nokogiri::HTML(body)
+    document = Nokogiri::HTML(body)
+    TAGS_TO_EXCLUDE.each do |tag|
+      document.search(tag).remove
+    end
+    document
   end
 
   def response

--- a/spec/services/html_scrapper_spec.rb
+++ b/spec/services/html_scrapper_spec.rb
@@ -24,10 +24,18 @@ RSpec.describe HtmlScraper do
         <html lang="en" class="govuk-template ">
           <head>
             <title>Blank page</title>
+            <style type="text/css">
+                body {
+                    background-color: #ffffff;
+                }
+            </style>
           </head>
           <body>
             <h1>Foo</h1>
             <p>Bar</p>
+            <script>
+              document.getElementById("example").innerHTML = "Hello JavaScript!";
+            </script>
           </body>
         </html>
       HTML


### PR DESCRIPTION
At the moment the remote content we get back from HTML pages includes tags such as `<style>`. We don't want the content of these tags to appear in the search, so we're excluding a list to remove from the content. We can add more tags to this list if we find more to exclude over time.

https://trello.com/c/0kPmvQ9A/19-add-edit-remove-information