### PR TITLE
Run db migrations on deployments to Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: rake db:migrate


### PR DESCRIPTION
Heroku's ruby buildpack doesn't run any database migrations when new versions are deployed. We can include a procfile to tell it to do this in the release phase:
https://devcenter.heroku.com/articles/release-phase#specifying-release-phase-tasks