### PR TITLE
Add url for elasticsearch on Heroku

### DIFF
--- a/config/chewy.yml
+++ b/config/chewy.yml
@@ -5,3 +5,5 @@ test:
   prefix: 'test'
 development:
   host: 'localhost:9200'
+production:
+  host: <%= ENV["ELASTICSEARCH_HOST_URL"] %>


### PR DESCRIPTION
This is the endpoint for our elasticsearch instance on heroku