### PR TITLE
Add background jobs via ActiveJob and Sidekiq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 /**/.DS_Store
 
 /node_modules
+
+# Redis file
+dump.rdb

--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,9 @@ gem "govuk_design_system_formbuilder"
 # Parsing tools
 gem "pdf-reader"
 
+# Background jobs
+gem "sidekiq"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem "govuk_design_system_formbuilder"
 gem "pdf-reader"
 
 # Background jobs
-gem "sidekiq"
+gem "sidekiq", "~> 6.5.0"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,8 +293,7 @@ GEM
     rainbow (3.1.1)
     raindrops (0.20.0)
     rake (13.0.6)
-    redis-client (0.12.2)
-      connection_pool
+    redis (4.8.1)
     regexp_parser (2.7.0)
     reline (0.3.2)
       io-console (~> 0.5)
@@ -365,11 +364,10 @@ GEM
       sentry-ruby (~> 5.8.0)
     sentry-ruby (5.8.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sidekiq (7.0.6)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.11.0)
+    sidekiq (6.5.8)
+      connection_pool (>= 2.2.5, < 3)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -444,7 +442,7 @@ DEPENDENCIES
   rspec-rails (~> 6.0.0)
   rubocop-govuk
   selenium-webdriver
-  sidekiq
+  sidekiq (~> 6.5.0)
   stimulus-rails
   turbo-rails
   tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       elasticsearch (>= 7.12.0, < 7.14.0)
       elasticsearch-dsl
     concurrent-ruby (1.2.0)
+    connection_pool (2.3.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -292,6 +293,8 @@ GEM
     rainbow (3.1.1)
     raindrops (0.20.0)
     rake (13.0.6)
+    redis-client (0.12.2)
+      connection_pool
     regexp_parser (2.7.0)
     reline (0.3.2)
       io-console (~> 0.5)
@@ -362,6 +365,11 @@ GEM
       sentry-ruby (~> 5.8.0)
     sentry-ruby (5.8.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sidekiq (7.0.6)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.11.0)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -436,6 +444,7 @@ DEPENDENCIES
   rspec-rails (~> 6.0.0)
   rubocop-govuk
   selenium-webdriver
+  sidekiq
   stimulus-rails
   turbo-rails
   tzinfo-data

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: rake db:migrate
-worker: bundle exec sidekiq -c 2
+worker: bundle exec sidekiq

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 release: rake db:migrate
+worker: bundle exec sidekiq -c 2

--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ redis locally. To run Sidekiq locally use the following command:
 sidekiq
 ```
 
+#### Sidekiq in Production
+If you deploy via the web Heroku interface the worker may not start. You can use
+the following command to check if the work is running:
+
+```bash
+heroku ps --app knowledge-hub
+```
+
+The output should be something like this:
+```bash
+=== web (Basic): bundle exec puma -C config/puma.rb (1)
+web.1: up 2023/03/03 18:21:42 +0000 (~ 8m ago)
+
+=== worker (Basic): bundle exec sidekiq (1)
+worker.1: up 2023/03/03 18:26:25 +0000 (~ 3m ago)
+```
+If the worker lines are missing the worker is not running.
+
+To start the worker use:
+```bash
+heroku ps:scale worker+1 --app knowledge-hub
+```
+
 ### Specs and Elasticsearch
 
 For the spec to pass, an instance of elasticsearch needs to be running on

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ A complimentary task will purge the database:
 rake elasticsearch:purge
 ```
 
+### ActiveJob
+Processing of indexes is done via ActiveJob and Sidekiq. This means the processing is done in a background job.
+
+In development, Sidekiq should be running for processing to run successfully. You may also need to install
+redis locally. To run Sidekiq locally use the following command:
+
+```bash
+sidekiq
+```
+
 ### Specs and Elasticsearch
 
 For the spec to pass, an instance of elasticsearch needs to be running on

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,4 +3,12 @@
 class ApplicationController < ActionController::Base
   require "govuk_design_system_formbuilder"
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+
+  # Use with an around action to enable the active job strategy
+  # which currently uses Sidekiq as the processing agent
+  def use_chewy_active_job_strategy(&block)
+    return yield if Rails.env.test?
+
+    Chewy.strategy(:active_job, &block)
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ItemsController < ApplicationController
+  around_action :use_chewy_active_job_strategy, only: %i[create update destroy]
+
   # GET /items
   def index
     @items = location.items.roots

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,8 @@ module KnowledgeHub
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Use Sidekiq as the default engine behind active job
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -1,0 +1,1 @@
+Chewy.root_strategy = :active_job

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+require "sidekiq/web"
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")
   root "home#index"
+
+  mount Sidekiq::Web => "/sidekiq"
 
   resources :locations do
     resources :items do

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,5 @@
+---
+:queues:
+  - chewy
+  - default
+

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,9 @@
 ---
+development:
+  :concurrency: 5
+production:
+  :concurrency: 10
+
 :queues:
   - chewy
   - default

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,7 +1,9 @@
 namespace :elasticsearch do
   desc "Index items into elasticsearch via import"
   task import: :environment do
-    ItemsIndex.import
+    Chewy.strategy(:active_job) do
+      ItemsIndex.import
+    end
   end
 
   desc "Purge items from elasticsearch"


### PR DESCRIPTION
Background jobs allow the index updates to be handled by a separate process. The processing is done via [Sidekiq](https://sidekiq.org/) and [ActiveJob](https://guides.rubyonrails.org/active_job_basics.html) provides a convenient wrapper so that consistent behaviour can be used across various background job services.

With this change in place a Sidekiq GUI is available at /sidekiq where the processing can be monitored.

<img width="1262" alt="sidekiq" src="https://user-images.githubusercontent.com/119297020/222197374-050d0ff8-88c7-48a9-b56f-6ae33c254e7f.png">

Note the updates to the README about running in development mode.

