### PR TITLE
Add location search

### DIFF
--- a/app/chewy/items_index.rb
+++ b/app/chewy/items_index.rb
@@ -4,4 +4,5 @@ class ItemsIndex < Chewy::Index
   field :description
   field :tag_list
   field :remote_content
+  field :location_id
 end

--- a/app/chewy/items_search.rb
+++ b/app/chewy/items_search.rb
@@ -1,19 +1,20 @@
 class ItemsSearch
   INDEX = ItemsIndex
 
-  def self.search(query)
-    new(query).search
+  def self.search(**args)
+    new(**args).search
   end
 
-  attr_reader :query
+  attr_reader :query, :location_id
 
-  def initialize(query)
+  def initialize(query:, location_id: nil)
     @query = query
+    @location_id = location_id
   end
 
   def search
     if query.present?
-      INDEX.query(
+      index.query(
         query_string: {
           fields: %i[name description tag_list remote_content],
           query:,
@@ -21,5 +22,15 @@ class ItemsSearch
         },
       )
     end
+  end
+
+  def index
+    return location_filter if location_id.present?
+
+    INDEX
+  end
+
+  def location_filter
+    INDEX.filter(match: { location_id: })
   end
 end

--- a/app/controllers/item_searches_controller.rb
+++ b/app/controllers/item_searches_controller.rb
@@ -1,5 +1,18 @@
 class ItemSearchesController < ApplicationController
   def index
-    @search = ItemsSearch.search(params[:query])
+    @search = ItemsSearch.search(query: params[:query], location_id:)
+  end
+
+private
+
+  def location_id
+    location.id if location
+  end
+
+  def location
+    return unless params[:id].present?
+
+    # finding the location to ensure id matches a location
+    @location ||= Location.find(params[:id])
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,6 +9,7 @@ class Item < ApplicationRecord
   acts_as_taggable_on :tags
 
   belongs_to :location
+
   has_many :comments, dependent: :destroy
   has_many :item_views, dependent: :destroy
 

--- a/app/views/item_searches/index.html.erb
+++ b/app/views/item_searches/index.html.erb
@@ -9,5 +9,8 @@
     <% end %>
   </ul>
 <% else %>
-  <p>No results found</p>
+  <p>
+    No results found <%= "for '#{params[:query]}'" %>
+    <%= "at #{@location.name}" if @location %>
+  </p>
 <% end %>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -1,8 +1,24 @@
 <%= govuk_breadcrumbs breadcrumbs: location_breadcrumbs(@location) %>
 
+<div class="location-search">
+  <%= form_tag(search_location_path(@location), method: :get) do %>
+    <label class="govuk-visually-hidden" for="location-search__input">
+      Search this location
+    </label>
+    <%= text_field_tag(
+          'query', params[:query],
+          id: "location-search__input",
+          class: "location-search__input govuk-input govuk-input--width-20",
+          placeholder: "Search this location"
+        ) %>
+    <%= submit_tag 'Search', class: "govuk-button govuk-button--secondary" %>
+  <% end %>
+</div>
+
 <%= render @location %>
 
 <h2><%= @location.name %> Items</h2>
+
 <ul>
   <% @location.items.each do |item| %>
     <li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :locations do
     member do
       get :new_sub_location
+      get :search, to: "item_searches#index"
     end
 
     resources :items do

--- a/spec/chewy/items_search_spec.rb
+++ b/spec/chewy/items_search_spec.rb
@@ -16,15 +16,35 @@ RSpec.describe ItemsSearch, elasticsearch: true do
     end
 
     it "returns the item if name matches" do
-      expect(described_class.search(text).documents).to include(item)
+      expect(described_class.search(query: text).documents).to include(item)
     end
 
     it "returns the item if the remote content matches" do
-      expect(described_class.search(remote_content).documents).to include(item)
+      expect(described_class.search(query: remote_content).documents).to include(item)
     end
 
     it "does not return anything if there is no match" do
-      expect(described_class.search("XXXX").documents).to be_empty
+      expect(described_class.search(query: "XXXX").documents).to be_empty
+    end
+
+    context "with item's location" do
+      let(:location_id) { item.location_id }
+
+      it "returns the item if name and location matches" do
+        expect(described_class.search(query: text, location_id:).documents).to include(item)
+      end
+
+      it "does not return anything if there is no match" do
+        expect(described_class.search(query: "XXXX", location_id:).documents).to be_empty
+      end
+    end
+
+    context "with another location" do
+      let(:location) { create :location }
+
+      it "does not return a match" do
+        expect(described_class.search(query: text, location_id: location.id).documents).to be_empty
+      end
     end
   end
 end

--- a/spec/requests/item_searches_spec.rb
+++ b/spec/requests/item_searches_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "ItemSearches", type: :request, elasticsearch: true do
-  describe "GET /index" do
+  describe "GET /item_searches" do
     it "returns http success" do
       get item_searches_path
       expect(response).to have_http_status(:success)
@@ -25,6 +25,45 @@ RSpec.describe "ItemSearches", type: :request, elasticsearch: true do
       it "displays a link to the matching item" do
         get item_searches_path, params: { query: text }
         expect(response.body).to include(location_item_path(item.location, item))
+      end
+    end
+  end
+
+  describe "GET /locations/:id/search" do
+    let(:location) { create :location }
+
+    it "returns http success" do
+      get search_location_path(location)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "states nothing found" do
+      get search_location_path(location)
+      expect(response.body).to include("No results found")
+    end
+
+    context "when passed a query" do
+      let(:text) { Faker::Lorem.word }
+      let(:item) { create :item, name: "Foo #{text} bar", location: }
+
+      before do
+        item
+        mock_callout_to_source_url_on_item_save
+        ItemsIndex.import
+      end
+
+      it "displays a link to the matching item" do
+        get search_location_path(location), params: { query: text }
+        expect(response.body).to include(location_item_path(item.location, item))
+      end
+
+      context "with a different location" do
+        let(:different_location) { create :location }
+
+        it "states nothing found" do
+          get search_location_path(different_location), params: { query: text }
+          expect(response.body).to include("No results found")
+        end
       end
     end
   end


### PR DESCRIPTION
[Trello ticket 63](https://trello.com/c/qvyGSs33/63-add-search-within-a-location)

This change allows a search to be made within a specific location.

With this change in place if there are two locations and only one of them contains an item containing "Foo":

- Using the site search for "Foo" will return the item
- Using the location search at the location containing "Foo" will return the item
- Using the location search at other location will not return the item.

Note that a location search will not find items in a sub-location. That is probably functionality that will be added later.

## Changes made

- Adds a location search form to locations#show view
- Adds location_id to the items search index
- Add a new route to items search that includes a location
- Updates ItemsSearch to have an optional location id input

## The new form in the location show view

![location_search](https://user-images.githubusercontent.com/119297020/225958876-8d319c77-9763-45c7-a7a5-9a9e37f192bd.png)
