### PR TITLE
Allow location filter to be altered to include sub-locations

### DIFF
--- a/app/chewy/items_search.rb
+++ b/app/chewy/items_search.rb
@@ -7,9 +7,11 @@ class ItemsSearch
 
   attr_reader :query, :location_id
 
-  def initialize(query:, location_id: nil)
+  def initialize(query:, location_id: [])
     @query = query
-    @location_id = location_id
+    @location_id = [location_id]
+    @location_id.flatten!
+    @location_id.compact!
   end
 
   def search
@@ -31,6 +33,6 @@ class ItemsSearch
   end
 
   def location_filter
-    INDEX.filter(match: { location_id: })
+    INDEX.filter(terms: { location_id: })
   end
 end

--- a/app/controllers/item_searches_controller.rb
+++ b/app/controllers/item_searches_controller.rb
@@ -6,7 +6,10 @@ class ItemSearchesController < ApplicationController
 private
 
   def location_id
-    location.id if location
+    return unless location
+    return location.id unless params[:include_sub_locations]
+
+    [location.id] + location.children.map(&:id)
   end
 
   def location

--- a/app/views/locations/_sub_location_search.html.erb
+++ b/app/views/locations/_sub_location_search.html.erb
@@ -1,0 +1,30 @@
+<div class="location-search">
+  <%= form_tag(search_location_path(location), method: :get) do %>
+    <%= label_tag(
+          "location-search__input",
+          "Search this location",
+          class:"govuk-visually-hidden"
+        ) %>
+    </label>
+    <%= text_field_tag(
+          'query', params[:query],
+          id: "location-search__input",
+          class: "location-search__input govuk-input govuk-input--width-20",
+          placeholder: "Search this location"
+        ) %>
+    <%= submit_tag 'Search', class: "govuk-button govuk-button--secondary" %>
+    <div class="govuk-checkboxes__item">
+      <%= check_box_tag(
+            :include_sub_locations,
+            "1",
+            true,
+            class: "govuk-checkboxes__input"
+          ) %>
+      <%= label_tag(
+            :include_sub_locations,
+            'Include sub-locations in search',
+            class: "govuk-label govuk-checkboxes__label"
+          ) %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -1,21 +1,8 @@
 <%= govuk_breadcrumbs breadcrumbs: location_breadcrumbs(@location) %>
 
-<div class="location-search">
-  <%= form_tag(search_location_path(@location), method: :get) do %>
-    <label class="govuk-visually-hidden" for="location-search__input">
-      Search this location
-    </label>
-    <%= text_field_tag(
-          'query', params[:query],
-          id: "location-search__input",
-          class: "location-search__input govuk-input govuk-input--width-20",
-          placeholder: "Search this location"
-        ) %>
-    <%= submit_tag 'Search', class: "govuk-button govuk-button--secondary" %>
-  <% end %>
-</div>
-
 <%= render @location %>
+
+
 
 <h2><%= @location.name %> Items</h2>
 
@@ -30,6 +17,9 @@
 <hr class="govuk-section-break govuk-section-break--visible">
 
 <div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= content_tag(:h2, "Sub-locations of #{@location.name}") if @location.children.present? %>
+  </div>
   <% @location.children.each do |sub_location| %>
     <div class="govuk-grid-column-one-half">
       <div class="sub-location">
@@ -45,4 +35,12 @@
       </div>
     </div>
   <% end %>
+</div>
+
+<hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "sub_location_search", location: @location %>
+  </div>
 </div>

--- a/spec/chewy/items_search_spec.rb
+++ b/spec/chewy/items_search_spec.rb
@@ -46,5 +46,23 @@ RSpec.describe ItemsSearch, elasticsearch: true do
         expect(described_class.search(query: text, location_id: location.id).documents).to be_empty
       end
     end
+
+    context "with two locations including the items" do
+      let(:other_location) { create :location }
+      let(:location_id) { [other_location.id, item.location_id] }
+
+      it "returns the item if name and location matches" do
+        expect(described_class.search(query: text, location_id:).documents).to include(item)
+      end
+    end
+
+    context "with two other locations" do
+      let(:other_locations) { create_list :location, 2 }
+      let(:location_id) { other_locations.map(&:id) }
+
+      it "does not return a match" do
+        expect(described_class.search(query: text, location_id:).documents).to be_empty
+      end
+    end
   end
 end

--- a/spec/requests/item_searches_spec.rb
+++ b/spec/requests/item_searches_spec.rb
@@ -65,6 +65,26 @@ RSpec.describe "ItemSearches", type: :request, elasticsearch: true do
           expect(response.body).to include("No results found")
         end
       end
+
+      context "with a sub-location" do
+        let(:parent_location) { create :location }
+        let(:location) { create :location, parent_id: parent_location.id }
+
+        it "states nothing found" do
+          get search_location_path(parent_location), params: { query: text }
+          expect(response.body).to include("No results found")
+        end
+      end
+
+      context "with a sub-location and include sub-locations selected" do
+        let(:parent_location) { create :location }
+        let(:location) { create :location, parent_id: parent_location.id }
+
+        it "displays a link to the matching item" do
+          get search_location_path(parent_location), params: { query: text, include_sub_locations: true }
+          expect(response.body).to include(location_item_path(item.location, item))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Adds a checkbox under the location search field to provide user the option of also searching child locations (sub-locations) of the current location.

As this also makes the search box a little more cluttered, I've moved it to the bottom of the page.

![location_search_with_sub_location](https://user-images.githubusercontent.com/119297020/226337158-e8383368-edf5-4905-beca-61398fa91aab.png)

In the example above, searching the location "CDDO" for "Foo" will find the item in "Son of CDDO" only if the new checkbox is ticked. 