### PR TITLE
Ensure redirects are followed by the content scraper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,8 @@ gem "sidekiq", "~> 6.5.0"
 # Seeding tool
 gem "dibber"
 
+gem "faraday-follow_redirects"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,8 @@ GEM
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
     faraday-httpclient (1.0.1)
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
@@ -439,6 +441,7 @@ DEPENDENCIES
   dibber
   factory_bot_rails
   faker
+  faraday-follow_redirects
   govspeak
   govuk-components
   govuk_design_system_formbuilder

--- a/app/services/content_scraper.rb
+++ b/app/services/content_scraper.rb
@@ -1,5 +1,7 @@
 # Returns the content from a remote resource
 class ContentScraper
+  require "faraday/follow_redirects"
+
   def self.call(url)
     new(url).content
   end
@@ -26,7 +28,11 @@ class ContentScraper
 private
 
   def response
-    Faraday.get(url)
+    conn = Faraday.new do |faraday|
+      faraday.response :follow_redirects
+    end
+
+    conn.get(url)
   end
 
   delegate :body, :headers, to: :response


### PR DESCRIPTION
If a request returned a 301 response, that response was used in the search. However we want redirects to be followed so we get the actual content of the page included in the search.